### PR TITLE
Update RayGunClient.cfc

### DIFF
--- a/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
+++ b/nz/co/ventego-creative/raygun4cfml/RaygunClient.cfc
@@ -99,6 +99,10 @@ limitations under the License.
             }
 		</cfscript>
 
+        	<!---  Remove // in case CF is adding it when serializing JSON (which is recommended in the CF Lockdown Guide)  --->
+        	<cfset jSONData = ReplaceNoCase(trim(jSONData), "//{", "{")>
+        	<cfset jSONData = ReplaceNoCase(trim(jSONData), "//[", "[")>
+
 		<cfhttp url="https://api.raygun.io/entries" method="post" charset="utf-8" result="postResult">
 			<cfhttpparam type="header" name="Content-Type" value="application/json"/>
 			<cfhttpparam type="header" name="X-ApiKey" value="#variables.apiKey#"/>


### PR DESCRIPTION
Fixes a 400 bad request error when Adobe ColdFusion is set to prefix serialized JSON with //.  This admin feature was introduced in ACF 8 and is a recommended setting in the CF Lockdown Guides.