### PR TITLE
Hotfix/fix line split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 raygun4cfml
 ===========
 
+Deploy under Components
+
 Raygun.io API client for CFML.
 
 Current Version: 1.1.0 (Jan 2 2016)

--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
@@ -38,7 +38,7 @@ limitations under the License.
 			var stackTraceLineElements = [];
 			var j = 0;
 
-			stackTraceLines = arguments.issueDataStruct.stacktrace.split("\sat");
+			stackTraceLines = arguments.issueDataStruct.stacktrace.split("\n\sat");
 			lenStackTraceLines = ArrayLen(stackTraceLines);
 
 			for (j=2;j<=lenStackTraceLines;j++)


### PR DESCRIPTION
Why:
- so that the stack lines are split correctly when the first line contains `at` like: `coldfusion.compiler.ParseException: Invalid CFML construct found on line 133 at column 80.` so that the second line where the loop starts is not `column 80`