### PR TITLE
except binary data to prevent error

### DIFF
--- a/src/nz/co/ventego-creative/raygun4cfml/RaygunRequestMessage.cfc
+++ b/src/nz/co/ventego-creative/raygun4cfml/RaygunRequestMessage.cfc
@@ -42,12 +42,13 @@ limitations under the License.
             returnContent["data"] = CGI;
             returnContent["form"] = FORM;
 
+            returnContent["rawData"] = JavaCast("null", "");
             if (CGI.CONTENT_TYPE != "text/html" && CGI.CONTENT_TYPE != "application/x-www-form-urlencoded" && CGI.REQUEST_METHOD != "GET") {
-                // TODO check if this is JSON and if yes, deserialise and apply content filter in some way here and then deserialise again
-                var temp = httpRequest.content;
-                returnContent["rawData"] = Left(temp, rawDataMaxLength);
-            } else {
-                returnContent["rawData"] = JavaCast("null","");
+                if(!isBinary(httpRequest.content)) {
+                    // TODO check if this is JSON and if yes, deserialise and apply content filter in some way here and then deserialise again
+                    var temp = httpRequest.content;
+                    returnContent["rawData"] = Left(temp, rawDataMaxLength);
+                }
             }
 
             return returnContent;


### PR DESCRIPTION
This fixes an error where the HTTP request content is binary.  The best approach might be to just wrap this in a try-catch since CF doesn't have a great way to test if some value is a string.