### PR TITLE
Support for response status code and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ History and Plan
 
 - Making Raygun4CFML a Coldbox module OR building a Coldbox module wrapper using Raygun4CFML as a dependency.
 - Add breadcrumbs (#46)
-
-2.0.2 Plan
-
-- Add support for response.statusCode (#48)
 - Integration and adaptation to Coldbox error reporting, adding CB HMVC app/API samples
 - Cleanup `legacy` directory
+
+2.1.0 (Jan 21 2025)
+
+- Add support for response.statusCode and statusDescription (#48)
 
 2.0.1 (Jan 13 2025)
 

--- a/samples/Application.cfc
+++ b/samples/Application.cfc
@@ -13,7 +13,7 @@ component {
      * Sets up the Raygun error tracking API key for exception monitoring
      */
     public void function onRequestStart() {
-        variables.RAYGUNAPIKEY = "erHT5l1N2VPfHW3E82kQQ";
+        variables.RAYGUNAPIKEY = "<YOUR API KEY>";
     }
 
 }

--- a/samples/Application.cfc
+++ b/samples/Application.cfc
@@ -13,7 +13,7 @@ component {
      * Sets up the Raygun error tracking API key for exception monitoring
      */
     public void function onRequestStart() {
-        variables.RAYGUNAPIKEY = "<YOUR API KEY>";
+        variables.RAYGUNAPIKEY = "erHT5l1N2VPfHW3E82kQQ";
     }
 
 }

--- a/samples/app-cfc-no-filter/missing_include.cfm
+++ b/samples/app-cfc-no-filter/missing_include.cfm
@@ -1,0 +1,1 @@
+<cfinclude template="i-am-missing.cfm">

--- a/samples/app-cfc-settings/Application.cfc
+++ b/samples/app-cfc-settings/Application.cfc
@@ -43,7 +43,8 @@ component extends="samples.Application" {
             .setFullName( "Tester" );
 
         // Increase max payload size to ensure detailed error data is captured
-        var settings = new com.raygun.environment.RaygunSettings().setRawDataMaxLength( 10000 );
+        // Set default status code to 418 to indicate that the error responses are from a teapot
+        var settings = new com.raygun.environment.RaygunSettings().setRawDataMaxLength( 10000 ).setStatusCode( 418 );
 
         var raygun = new com.raygun.RaygunClient(
             apiKey     = variables.RAYGUNAPIKEY,

--- a/server-adobe-2023.json
+++ b/server-adobe-2023.json
@@ -9,5 +9,8 @@
         "http":{
             "port":"9193"
         }
+    },
+    "scripts":{
+        "onServerInitialInstall":"cfpm install debugger"
     }
 }

--- a/src/com/raygun/RaygunClient.cfc
+++ b/src/com/raygun/RaygunClient.cfc
@@ -136,13 +136,13 @@ component accessors="true" {
             augmentedIssueData[ "groupingKey" ] = arguments.groupingKey;
         }
 
-        var message        = new message.RaygunMessage();
         var raygunSettings = {};
         // Only apply settings if they've been properly initialized
         if ( isInstanceOf( getSettings(), "RaygunSettings" ) ) {
             var raygunSettings = getSettings().getSettings();
         }
-        var messageContent = message.build( augmentedIssueData, raygunSettings );
+
+        var messageContent = new message.RaygunMessage(settings = raygunSettings).build( augmentedIssueData );
 
         // Apply content filtering if configured to protect sensitive data
         if (

--- a/src/com/raygun/RaygunClient.cfc
+++ b/src/com/raygun/RaygunClient.cfc
@@ -142,7 +142,7 @@ component accessors="true" {
             var raygunSettings = getSettings().getSettings();
         }
 
-        var messageContent = new message.RaygunMessage(settings = raygunSettings).build( augmentedIssueData );
+        var messageContent = new message.RaygunMessage( settings = raygunSettings ).build( augmentedIssueData );
 
         // Apply content filtering if configured to protect sensitive data
         if (

--- a/src/com/raygun/environment/RaygunConfig.cfc
+++ b/src/com/raygun/environment/RaygunConfig.cfc
@@ -13,6 +13,9 @@ component {
         RAYGUN_CLIENT_NAME    = "raygun4cfml";
         RAYGUN_CLIENT_VERSION = "2.0.1";
         RAYGUN_CLIENT_URL     = "https://github.com/MindscapeHQ/raygun4cfml";
+
+        // New default status code
+        DEFAULT_STATUS_CODE = 500;
     }
 
     /**
@@ -49,6 +52,13 @@ component {
      */
     public static function getRaygunClientUrl() {
         return static.RAYGUN_CLIENT_URL;
+    }
+
+    /**
+     * Returns the default HTTP status code for error responses.
+     */
+    public static function getDefaultStatusCode() {
+        return static.DEFAULT_STATUS_CODE;
     }
 
 }

--- a/src/com/raygun/environment/RaygunSettings.cfc
+++ b/src/com/raygun/environment/RaygunSettings.cfc
@@ -8,16 +8,22 @@ component accessors="true" {
      * This helps prevent memory issues and ensures consistent API payload sizes.
      */
     property name="rawDataMaxLength" type="numeric";
-    property name="statusCode" type="numeric";
+    property name="statusCode"       type="numeric";
 
-    public RaygunSettings function init( numeric rawDataMaxLength = com.raygun.environment.RaygunConfig::RAW_DATA_MAX_LENGTH_DEFAULT, numeric statusCode = com.raygun.environment.RaygunConfig::getDefaultStatusCode() ) {
+    public RaygunSettings function init(
+        numeric rawDataMaxLength = com.raygun.environment.RaygunConfig::RAW_DATA_MAX_LENGTH_DEFAULT,
+        numeric statusCode       = com.raygun.environment.RaygunConfig::getDefaultStatusCode()
+    ) {
         setRawDataMaxLength( rawDataMaxLength );
         setStatusCode( statusCode );
         return this;
     }
 
     public struct function getSettings() {
-        return { "rawDataMaxLength" : getRawDataMaxLength(), "statusCode" : getStatusCode() };
+        return {
+            "rawDataMaxLength" : getRawDataMaxLength(),
+            "statusCode"       : getStatusCode()
+        };
     }
 
 }

--- a/src/com/raygun/environment/RaygunSettings.cfc
+++ b/src/com/raygun/environment/RaygunSettings.cfc
@@ -8,14 +8,16 @@ component accessors="true" {
      * This helps prevent memory issues and ensures consistent API payload sizes.
      */
     property name="rawDataMaxLength" type="numeric";
+    property name="statusCode" type="numeric";
 
-    public RaygunSettings function init( numeric rawDataMaxLength = com.raygun.environment.RaygunConfig::RAW_DATA_MAX_LENGTH_DEFAULT ) {
+    public RaygunSettings function init( numeric rawDataMaxLength = com.raygun.environment.RaygunConfig::RAW_DATA_MAX_LENGTH_DEFAULT, numeric statusCode = com.raygun.environment.RaygunConfig::getDefaultStatusCode() ) {
         setRawDataMaxLength( rawDataMaxLength );
+        setStatusCode( statusCode );
         return this;
     }
 
     public struct function getSettings() {
-        return { "rawDataMaxLength" : getRawDataMaxLength() };
+        return { "rawDataMaxLength" : getRawDataMaxLength(), "statusCode" : getStatusCode() };
     }
 
 }

--- a/src/com/raygun/message/RaygunMessage.cfc
+++ b/src/com/raygun/message/RaygunMessage.cfc
@@ -11,10 +11,18 @@ component accessors="true" {
     // Handles the detailed error information including stack traces, request data, etc
     property name="raygunMessageDetails" type="RaygunMessageDetails";
 
-    public RaygunMessage function init( RaygunMessageDetails raygunMessageDetails, struct settings = {} ) {
+    public RaygunMessage function init(
+        RaygunMessageDetails raygunMessageDetails,
+        struct settings = {}
+    ) {
         setSettings( arguments.settings );
-        setRaygunMessageDetails( !isNull(arguments.raygunMessageDetails) && isInstanceOf(arguments.raygunMessageDetails, "RaygunMessageDetails") ? arguments.raygunMessageDetails : new raygunMessageDetails( settings = getSettings() ) );
-        
+        setRaygunMessageDetails(
+            !isNull( arguments.raygunMessageDetails ) && isInstanceOf(
+                arguments.raygunMessageDetails,
+                "RaygunMessageDetails"
+            ) ? arguments.raygunMessageDetails : new RaygunMessageDetails( settings = getSettings() )
+        );
+
         return this;
     }
 
@@ -26,17 +34,13 @@ component accessors="true" {
      *
      * @issueData The struct containing issue data augmented with Raygun-specific data
      */
-    public struct function build(
-        required struct issueData
-    ) {
+    public struct function build( required struct issueData ) {
         var returnContent = {};
         // Convert to UTC for consistent timestamps across different server timezones
         var ts            = dateConvert( "local2Utc", now() );
 
         returnContent[ "occurredOn" ] = ts.dateFormat( "yyyy-mm-dd" ) & "T" & ts.timeFormat( "HH:mm:ss" ) & "Z";
-        returnContent[ "details" ]    = raygunMessageDetails.build(
-            arguments.issueData
-        );
+        returnContent[ "details" ]    = raygunMessageDetails.build( arguments.issueData );
 
         return returnContent;
     }

--- a/src/com/raygun/message/RaygunMessage.cfc
+++ b/src/com/raygun/message/RaygunMessage.cfc
@@ -6,11 +6,15 @@
  */
 component accessors="true" {
 
+    property name="settings" type="struct";
+
     // Handles the detailed error information including stack traces, request data, etc
     property name="raygunMessageDetails" type="RaygunMessageDetails";
 
-    public RaygunMessage function init( RaygunMessageDetails raygunMessageDetails = new RaygunMessageDetails() ) {
-        setRaygunMessageDetails( arguments.raygunMessageDetails );
+    public RaygunMessage function init( RaygunMessageDetails raygunMessageDetails, struct settings = {} ) {
+        setSettings( arguments.settings );
+        setRaygunMessageDetails( !isNull(arguments.raygunMessageDetails) && isInstanceOf(arguments.raygunMessageDetails, "RaygunMessageDetails") ? arguments.raygunMessageDetails : new raygunMessageDetails( settings = getSettings() ) );
+        
         return this;
     }
 
@@ -21,11 +25,9 @@ component accessors="true" {
      * consistent error chronology across different server timezones.
      *
      * @issueData The struct containing issue data augmented with Raygun-specific data
-     * @settings Optional configuration settings that modify message construction
      */
     public struct function build(
-        required struct issueData,
-        struct settings = {}
+        required struct issueData
     ) {
         var returnContent = {};
         // Convert to UTC for consistent timestamps across different server timezones
@@ -33,8 +35,7 @@ component accessors="true" {
 
         returnContent[ "occurredOn" ] = ts.dateFormat( "yyyy-mm-dd" ) & "T" & ts.timeFormat( "HH:mm:ss" ) & "Z";
         returnContent[ "details" ]    = raygunMessageDetails.build(
-            arguments.issueData,
-            arguments.settings
+            arguments.issueData
         );
 
         return returnContent;

--- a/src/com/raygun/message/RaygunMessageDetails.cfc
+++ b/src/com/raygun/message/RaygunMessageDetails.cfc
@@ -1,25 +1,33 @@
 /**
  * Represents the core message details for a Raygun error report.
  * This component aggregates all the different aspects of an error report including
- * exception details, request information, client data, and environment specifics.
+ * exception details, request information, client data, environment specifics, and response data.
  */
 component accessors="true" {
+
+    property name="settings" type="struct";
 
     property name="raygunExceptionMessage"   type="RaygunExceptionMessage";
     property name="raygunRequestMessage"     type="RaygunRequestMessage";
     property name="raygunClientMessage"      type="RaygunClientMessage";
     property name="raygunEnvironmentMessage" type="RaygunEnvironmentMessage";
+    property name="raygunResponseMessage"    type="RaygunResponseMessage";
 
     public RaygunMessageDetails function init(
-        RaygunExceptionMessage raygunExceptionMessage     = new RaygunExceptionMessage(),
-        RaygunRequestMessage raygunRequestMessage         = new RaygunRequestMessage(),
-        RaygunClientMessage raygunClientMessage           = new RaygunClientMessage(),
-        RaygunEnvironmentMessage raygunEnvironmentMessage = new RaygunEnvironmentMessage()
+        RaygunExceptionMessage raygunExceptionMessage,
+        RaygunRequestMessage raygunRequestMessage,
+        RaygunClientMessage raygunClientMessage,
+        RaygunEnvironmentMessage raygunEnvironmentMessage,
+        RaygunResponseMessage raygunResponseMessage,
+        struct settings = {}
     ) {
-        setRaygunExceptionMessage( arguments.raygunExceptionMessage );
-        setRaygunRequestMessage( arguments.raygunRequestMessage );
-        setRaygunClientMessage( arguments.raygunClientMessage );
-        setRaygunEnvironmentMessage( arguments.raygunEnvironmentMessage );
+        setSettings( arguments.settings );
+        setRaygunExceptionMessage( !isNull(arguments.raygunExceptionMessage) && isInstanceOf(arguments.raygunExceptionMessage, "RaygunExceptionMessage") ? arguments.raygunExceptionMessage : new RaygunExceptionMessage() );
+        setRaygunRequestMessage( !isNull(arguments.raygunRequestMessage) && isInstanceOf(arguments.raygunRequestMessage, "RaygunRequestMessage") ? arguments.raygunRequestMessage : new RaygunRequestMessage() );
+        setRaygunClientMessage( !isNull(arguments.raygunClientMessage) && isInstanceOf(arguments.raygunClientMessage, "RaygunClientMessage") ? arguments.raygunClientMessage : new RaygunClientMessage() );
+        setRaygunEnvironmentMessage( !isNull(arguments.raygunEnvironmentMessage) && isInstanceOf(arguments.raygunEnvironmentMessage, "RaygunEnvironmentMessage") ? arguments.raygunEnvironmentMessage : new RaygunEnvironmentMessage() );
+        setRaygunResponseMessage( !isNull(arguments.raygunResponseMessage) && isInstanceOf(arguments.raygunResponseMessage, "RaygunResponseMessage") ? arguments.raygunResponseMessage : new RaygunResponseMessage( settings = getSettings() ) );
+    
         return this;
     }
 
@@ -32,8 +40,7 @@ component accessors="true" {
      * @settings Optional configuration settings that may affect how the request data is processed
      */
     public struct function build(
-        required struct issueData,
-        struct settings = {}
+        required struct issueData
     ) {
         var returnContent = {};
 
@@ -58,9 +65,12 @@ component accessors="true" {
 
         // Build the core components of the error report
         returnContent[ "error" ]       = raygunExceptionMessage.build( arguments.issueData );
-        returnContent[ "request" ]     = raygunRequestMessage.build( arguments.settings );
+        returnContent[ "request" ]     = raygunRequestMessage.build( getSettings() );
         returnContent[ "client" ]      = raygunClientMessage.build();
         returnContent[ "environment" ] = raygunEnvironmentMessage.build();
+        // writeDump(raygunResponseMessage);
+        // writeDump(getSettings());
+        returnContent[ "response" ]    = raygunResponseMessage.build( arguments.issueData);
 
         // Include any custom data if provided through a builder object
         if ( arguments.issueData.keyExists( "userCustomData" ) && isObject( arguments.issueData.userCustomData ) ) {

--- a/src/com/raygun/message/RaygunMessageDetails.cfc
+++ b/src/com/raygun/message/RaygunMessageDetails.cfc
@@ -37,7 +37,6 @@ component accessors="true" {
      * that matches Raygun's API expectations.
      *
      * @issueData The core error data to be processed
-     * @settings Optional configuration settings that may affect how the request data is processed
      */
     public struct function build(
         required struct issueData

--- a/src/com/raygun/message/RaygunMessageDetails.cfc
+++ b/src/com/raygun/message/RaygunMessageDetails.cfc
@@ -68,8 +68,6 @@ component accessors="true" {
         returnContent[ "request" ]     = raygunRequestMessage.build( getSettings() );
         returnContent[ "client" ]      = raygunClientMessage.build();
         returnContent[ "environment" ] = raygunEnvironmentMessage.build();
-        // writeDump(raygunResponseMessage);
-        // writeDump(getSettings());
         returnContent[ "response" ]    = raygunResponseMessage.build( arguments.issueData);
 
         // Include any custom data if provided through a builder object

--- a/src/com/raygun/message/RaygunMessageDetails.cfc
+++ b/src/com/raygun/message/RaygunMessageDetails.cfc
@@ -22,12 +22,37 @@ component accessors="true" {
         struct settings = {}
     ) {
         setSettings( arguments.settings );
-        setRaygunExceptionMessage( !isNull(arguments.raygunExceptionMessage) && isInstanceOf(arguments.raygunExceptionMessage, "RaygunExceptionMessage") ? arguments.raygunExceptionMessage : new RaygunExceptionMessage() );
-        setRaygunRequestMessage( !isNull(arguments.raygunRequestMessage) && isInstanceOf(arguments.raygunRequestMessage, "RaygunRequestMessage") ? arguments.raygunRequestMessage : new RaygunRequestMessage() );
-        setRaygunClientMessage( !isNull(arguments.raygunClientMessage) && isInstanceOf(arguments.raygunClientMessage, "RaygunClientMessage") ? arguments.raygunClientMessage : new RaygunClientMessage() );
-        setRaygunEnvironmentMessage( !isNull(arguments.raygunEnvironmentMessage) && isInstanceOf(arguments.raygunEnvironmentMessage, "RaygunEnvironmentMessage") ? arguments.raygunEnvironmentMessage : new RaygunEnvironmentMessage() );
-        setRaygunResponseMessage( !isNull(arguments.raygunResponseMessage) && isInstanceOf(arguments.raygunResponseMessage, "RaygunResponseMessage") ? arguments.raygunResponseMessage : new RaygunResponseMessage( settings = getSettings() ) );
-    
+        setRaygunExceptionMessage(
+            !isNull( arguments.raygunExceptionMessage ) && isInstanceOf(
+                arguments.raygunExceptionMessage,
+                "RaygunExceptionMessage"
+            ) ? arguments.raygunExceptionMessage : new RaygunExceptionMessage()
+        );
+        setRaygunRequestMessage(
+            !isNull( arguments.raygunRequestMessage ) && isInstanceOf(
+                arguments.raygunRequestMessage,
+                "RaygunRequestMessage"
+            ) ? arguments.raygunRequestMessage : new RaygunRequestMessage()
+        );
+        setRaygunClientMessage(
+            !isNull( arguments.raygunClientMessage ) && isInstanceOf(
+                arguments.raygunClientMessage,
+                "RaygunClientMessage"
+            ) ? arguments.raygunClientMessage : new RaygunClientMessage()
+        );
+        setRaygunEnvironmentMessage(
+            !isNull( arguments.raygunEnvironmentMessage ) && isInstanceOf(
+                arguments.raygunEnvironmentMessage,
+                "RaygunEnvironmentMessage"
+            ) ? arguments.raygunEnvironmentMessage : new RaygunEnvironmentMessage()
+        );
+        setRaygunResponseMessage(
+            !isNull( arguments.raygunResponseMessage ) && isInstanceOf(
+                arguments.raygunResponseMessage,
+                "RaygunResponseMessage"
+            ) ? arguments.raygunResponseMessage : new RaygunResponseMessage( settings = getSettings() )
+        );
+
         return this;
     }
 
@@ -38,9 +63,7 @@ component accessors="true" {
      *
      * @issueData The core error data to be processed
      */
-    public struct function build(
-        required struct issueData
-    ) {
+    public struct function build( required struct issueData ) {
         var returnContent = {};
 
         // Grouping key allows for custom error grouping in Raygun's dashboard
@@ -67,7 +90,7 @@ component accessors="true" {
         returnContent[ "request" ]     = raygunRequestMessage.build( getSettings() );
         returnContent[ "client" ]      = raygunClientMessage.build();
         returnContent[ "environment" ] = raygunEnvironmentMessage.build();
-        returnContent[ "response" ]    = raygunResponseMessage.build( arguments.issueData);
+        returnContent[ "response" ]    = raygunResponseMessage.build( arguments.issueData );
 
         // Include any custom data if provided through a builder object
         if ( arguments.issueData.keyExists( "userCustomData" ) && isObject( arguments.issueData.userCustomData ) ) {

--- a/src/com/raygun/message/RaygunRequestMessage.cfc
+++ b/src/com/raygun/message/RaygunRequestMessage.cfc
@@ -9,7 +9,7 @@ component accessors="true" {
 
     public RaygunRequestMessage function init( struct settings = {} ) {
         setSettings( arguments.settings );
-        
+
         return this;
     }
 

--- a/src/com/raygun/message/RaygunRequestMessage.cfc
+++ b/src/com/raygun/message/RaygunRequestMessage.cfc
@@ -3,9 +3,13 @@
  * Captures essential request context including headers, form data, and raw request content
  * while gracefully handling cases where certain scopes might be unavailable.
  */
-component {
+component accessors="true" {
 
-    public RaygunRequestMessage function init() {
+    property name="settings" type="struct";
+
+    public RaygunRequestMessage function init( struct settings = {} ) {
+        setSettings( arguments.settings );
+        
         return this;
     }
 
@@ -14,10 +18,8 @@ component {
      * Uses multiple data sources (CGI, FORM, URL scopes) with fallbacks to ensure
      * we capture as much context as possible even if some scopes are restricted.
      * Raw request data is truncated to prevent oversized payloads.
-     *
-     * @settings Optional configuration settings, primarily for controlling raw data length
      */
-    public struct function build( struct settings = {} ) {
+    public struct function build() {
         var returnContent = {};
 
         // Safely access request data - some environments restrict getHTTPRequestData()
@@ -69,7 +71,7 @@ component {
             len( CGI.CONTENT_TYPE ) && len( CGI.REQUEST_METHOD ) && CGI.CONTENT_TYPE != "text/html" && CGI.CONTENT_TYPE != "application/x-www-form-urlencoded" && CGI.REQUEST_METHOD != "GET"
         ) {
             var maxLength = (
-                arguments.settings.keyExists( "rawDataMaxLength" ) ? arguments.settings.rawDataMaxLength : com.raygun.environment.RaygunConfig::getRawDataMaxLengthDefault()
+                getSettings().keyExists( "rawDataMaxLength" ) ? getSettings().rawDataMaxLength : com.raygun.environment.RaygunConfig::getRawDataMaxLengthDefault()
             );
             returnContent[ "rawData" ] = left(
                 ( httpRequest.keyExists( "content" ) ) ? httpRequest.content : javacast( "null", "" ),

--- a/src/com/raygun/message/RaygunResponseMessage.cfc
+++ b/src/com/raygun/message/RaygunResponseMessage.cfc
@@ -1,0 +1,31 @@
+/**
+ * Represents the response information to be included in the Raygun message.
+ */
+component accessors="true" {
+
+    property name="settings" type="struct";
+
+    public RaygunResponseMessage function init( struct settings = {} ) {
+        setSettings( arguments.settings );
+        
+        return this;
+    }
+
+    /**
+     * Determines the status code based on the exception type.
+     * @param errorData The error structure from the crash report
+     */
+    private numeric function determineStatusCode( required struct errorData ) {
+        if ( errorData.type == "MissingInclude" ) {
+            return 404;
+        } 
+        
+        return ( getSettings().keyExists( "statusCode" ) ? getSettings().statusCode : com.raygun.environment.RaygunConfig::getDefaultStatusCode() );
+    }
+
+    public struct function build( required struct errorData ) {
+        return {
+            "statusCode": determineStatusCode( arguments.errorData )
+        };
+    }
+} 

--- a/src/com/raygun/message/RaygunResponseMessage.cfc
+++ b/src/com/raygun/message/RaygunResponseMessage.cfc
@@ -5,9 +5,74 @@ component accessors="true" {
 
     property name="settings" type="struct";
 
+    static {
+        HTTP_STATUS_CODES = {
+            200 : "OK",
+            201 : "Created",
+            202 : "Accepted",
+            203 : "Non-Authoritative Information",
+            204 : "No Content",
+            205 : "Reset Content",
+            206 : "Partial Content",
+            207 : "Multi-Status",
+            208 : "Already Reported",
+            218 : "This is fine",
+            226 : "IM Used",
+            301 : "Moved Permanently",
+            302 : "Found",
+            303 : "See Other",
+            304 : "Not Modified",
+            305 : "Use Proxy",
+            306 : "Switch Proxy",
+            307 : "Temporary Redirect",
+            308 : "Permanent Redirect",
+            400 : "Bad Request",
+            401 : "Unauthorized",
+            402 : "Payment Required",
+            403 : "Forbidden",
+            404 : "Not Found",
+            405 : "Method Not Allowed",
+            406 : "Not Acceptable",
+            407 : "Proxy Authentication Required",
+            408 : "Request Timeout",
+            409 : "Conflict",
+            410 : "Gone",
+            411 : "Length Required",
+            412 : "Precondition Failed",
+            413 : "Payload Too Large",
+            414 : "URI Too Long",
+            415 : "Unsupported Media Type",
+            416 : "Range Not Satisfiable",
+            417 : "Expectation Failed",
+            418 : "I'm a teapot",
+            421 : "Misdirected Request",
+            422 : "Unprocessable Entity",
+            423 : "Locked",
+            424 : "Failed Dependency",
+            425 : "Too Early",
+            426 : "Upgrade Required",
+            428 : "Precondition Required",
+            429 : "Too Many Requests",
+            431 : "Request Header Fields Too Large",
+            451 : "Unavailable For Legal Reasons",
+            500 : "Internal Server Error",
+            501 : "Not Implemented",
+            502 : "Bad Gateway",
+            503 : "Service Unavailable",
+            504 : "Gateway Timeout",
+            505 : "HTTP Version Not Supported",
+            506 : "Variant Also Negotiates",
+            507 : "Insufficient Storage",
+            508 : "Loop Detected",
+            509 : "Bandwidth Limit Exceeded",
+            510 : "Not Extended",
+            511 : "Network Authentication Required"
+        };
+    }
+
     public RaygunResponseMessage function init( struct settings = {} ) {
         setSettings( arguments.settings );
-        
+
         return this;
     }
 
@@ -18,14 +83,19 @@ component accessors="true" {
     private numeric function determineStatusCode( required struct errorData ) {
         if ( errorData.type == "MissingInclude" ) {
             return 404;
-        } 
-        
-        return ( getSettings().keyExists( "statusCode" ) ? getSettings().statusCode : com.raygun.environment.RaygunConfig::getDefaultStatusCode() );
+        }
+
+        return (
+            getSettings().keyExists( "statusCode" ) ? getSettings().statusCode : com.raygun.environment.RaygunConfig::getDefaultStatusCode()
+        );
     }
 
     public struct function build( required struct errorData ) {
+        var sc = determineStatusCode( arguments.errorData );
         return {
-            "statusCode": determineStatusCode( arguments.errorData )
+            "statusCode"        : sc,
+            "statusDescription" : ( structKeyExists( static.HTTP_STATUS_CODES, sc ) ? static.HTTP_STATUS_CODES[ sc ] : "" )
         };
     }
-} 
+
+}


### PR DESCRIPTION
## #48 - Response structure

### Description :memo:
- **Purpose**: Fixes #48 
- **Approach**: Adds `response` structure and returns 500 (or an otherwise specific default status code) resp a 404 (for CFML `MissingIncludes`).

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
