### PR TITLE
test: expand Lucee engine matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,15 @@ jobs:
   tests:
     name: ${{ matrix.engine }}
     runs-on: ubuntu-latest
+    env:
+      BOX_CONFIG_MODULESEXCLUDE: '["commandbox-cfconfig"]'
     strategy:
       fail-fast: false
       matrix:
         include:
+          - engine: Lucee 8.0 Alpha
+            config: server-lucee-8-0.json
+            port: 9202
           - engine: Lucee 7.1
             config: server-lucee-7-1.json
             port: 9201
@@ -35,6 +40,30 @@ jobs:
           - engine: Lucee 5.3
             config: server-lucee-5-3.json
             port: 9196
+          - engine: Lucee Light 8.0 Alpha
+            config: server-lucee-light-8-0.json
+            port: 9210
+          - engine: Lucee Light 7.1
+            config: server-lucee-light-7-1.json
+            port: 9209
+          - engine: Lucee Light 7.0
+            config: server-lucee-light-7-0.json
+            port: 9208
+          - engine: Lucee Light 6.2
+            config: server-lucee-light-6-2.json
+            port: 9207
+          - engine: Lucee Light 6.1
+            config: server-lucee-light-6-1.json
+            port: 9206
+          - engine: Lucee Light 6.0
+            config: server-lucee-light-6-0.json
+            port: 9205
+          - engine: Lucee Light 5.4
+            config: server-lucee-light-5-4.json
+            port: 9204
+          - engine: Lucee Light 5.3
+            config: server-lucee-light-5-3.json
+            port: 9203
           - engine: Adobe CF 2025
             config: server-adobe-2025.json
             port: 9198

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Raygun4CFML (v3.0.0) is a CFML library for sending crash reports to the [Raygun 
 - **Lucee** 5.3, 5.4, 6.0, 6.1, 6.2, 7.0, 7.1
 - **BoxLang** 1+
 
-Package management via CommandBox (`box.json`). Code formatting via cfformat (`.cfformat.json`). Tests via TestBox (160 specs across 11 engines).
+Package management via CommandBox (`box.json`). Code formatting via cfformat (`.cfformat.json`). Tests via TestBox (174 specs across 20 engines).
 
 ## Repository Layout
 
@@ -106,7 +106,7 @@ All code must work on Adobe CF 2021+, Lucee 5.3+, and BoxLang 1+.
 - Test files are named `*Test.cfc` and extend `testbox.system.BaseSpec`
 - TestBox is a dev dependency (`"testbox": "6"` in `box.json`)
 - Test any behavior change; verify against multiple engines when touching engine-dependent code
-- **160 specs** across all components — run all 11 engines before pushing
+- **174 specs** across all components — run all 20 engines before pushing
 
 ### Running tests locally
 
@@ -194,6 +194,7 @@ Formatting covers `src/**/*.cfc`, `tests/**/*.cfc`, `tests/**/*.cfm`, `samples/*
 
 | File | Engine | Port |
 |---|---|---|
+| `server-lucee-8-0.json` | Lucee 8.0 Alpha | 9202 |
 | `server-lucee-5-3.json` | Lucee 5.3 | 9196 |
 | `server-lucee-5-4.json` | Lucee 5.4 | 9191 |
 | `server-lucee-6-0.json` | Lucee 6.0 | 9194 |
@@ -201,6 +202,14 @@ Formatting covers `src/**/*.cfc`, `tests/**/*.cfc`, `tests/**/*.cfm`, `samples/*
 | `server-lucee-6-2.json` | Lucee 6.2 | 9199 |
 | `server-lucee-7-0.json` | Lucee 7.0 | 9200 |
 | `server-lucee-7-1.json` | Lucee 7.1 | 9201 |
+| `server-lucee-light-5-3.json` | Lucee Light 5.3 | 9203 |
+| `server-lucee-light-5-4.json` | Lucee Light 5.4 | 9204 |
+| `server-lucee-light-6-0.json` | Lucee Light 6.0 | 9205 |
+| `server-lucee-light-6-1.json` | Lucee Light 6.1 | 9206 |
+| `server-lucee-light-6-2.json` | Lucee Light 6.2 | 9207 |
+| `server-lucee-light-7-0.json` | Lucee Light 7.0 | 9208 |
+| `server-lucee-light-7-1.json` | Lucee Light 7.1 | 9209 |
+| `server-lucee-light-8-0.json` | Lucee Light 8.0 Alpha | 9210 |
 | `server-adobe-2021.json` | Adobe CF 2021 | 9192 |
 | `server-adobe-2023.json` | Adobe CF 2023 | 9193 |
 | `server-adobe-2025.json` | Adobe CF 2025 | 9198 |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CFML client library for [Raygun Crash Reporting](https://raygun.com).
 
 ## Active Development
 
-3.0.0 adds breadcrumbs, onBeforeSend hooks, ignore exceptions, wildcard content filtering, payload size enforcement, configurable API endpoint/timeout, automatic retry, and additional environment fields — plus numerous bug fixes and 160 test specs across 11 engines.
+3.0.0 adds breadcrumbs, onBeforeSend hooks, ignore exceptions, wildcard content filtering, payload size enforcement, configurable API endpoint/timeout, automatic retry, and additional environment fields — plus numerous bug fixes and 174 test specs across 20 engines.
 
 Please be aware that no testing and work has *yet* gone into framework-specific crash reports, e.g. a deeper integration with Coldbox HMVC, Fusebox, CF on Wheels etc. This will be added over time in future releases.
 
@@ -520,7 +520,7 @@ box run-script format:check    # check formatting without modifying files
 
 ```bash
 ./run-tests.sh server-lucee-6-1.json    # single engine
-./run-tests.sh                           # all 11 engines sequentially
+./run-tests.sh                           # all 20 engines sequentially
 box run-script test                      # shortcut: Lucee 6.1
 box run-script test:all                  # shortcut: all engines
 ```
@@ -529,6 +529,7 @@ box run-script test:all                  # shortcut: all engines
 
 | Server Config | Engine | Port |
 |---|---|---|
+| `server-lucee-8-0.json` | Lucee 8.0 Alpha | 9202 |
 | `server-lucee-5-3.json` | Lucee 5.3 | 9196 |
 | `server-lucee-5-4.json` | Lucee 5.4 | 9191 |
 | `server-lucee-6-0.json` | Lucee 6.0 | 9194 |
@@ -536,6 +537,14 @@ box run-script test:all                  # shortcut: all engines
 | `server-lucee-6-2.json` | Lucee 6.2 | 9199 |
 | `server-lucee-7-0.json` | Lucee 7.0 | 9200 |
 | `server-lucee-7-1.json` | Lucee 7.1 | 9201 |
+| `server-lucee-light-5-3.json` | Lucee Light 5.3 | 9203 |
+| `server-lucee-light-5-4.json` | Lucee Light 5.4 | 9204 |
+| `server-lucee-light-6-0.json` | Lucee Light 6.0 | 9205 |
+| `server-lucee-light-6-1.json` | Lucee Light 6.1 | 9206 |
+| `server-lucee-light-6-2.json` | Lucee Light 6.2 | 9207 |
+| `server-lucee-light-7-0.json` | Lucee Light 7.0 | 9208 |
+| `server-lucee-light-7-1.json` | Lucee Light 7.1 | 9209 |
+| `server-lucee-light-8-0.json` | Lucee Light 8.0 Alpha | 9210 |
 | `server-adobe-2021.json` | Adobe ColdFusion 2021 | 9192 |
 | `server-adobe-2023.json` | Adobe ColdFusion 2023 | 9193 |
 | `server-adobe-2025.json` | Adobe ColdFusion 2025 | 9198 |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ Before starting the release process:
 - [ ] `README.md` reflects the current API and features
 - [ ] Samples in `samples/` are updated for any new features
 - [ ] `box run-script format:check` passes with no issues
-- [ ] All tests pass on all 11 engines: `./run-tests.sh`
+- [ ] All tests pass on all 20 engines: `./run-tests.sh`
 
 ## Version Locations
 
@@ -58,7 +58,7 @@ Change the `(Unreleased)` marker to the version and date:
 ./run-tests.sh
 ```
 
-All 11 engines must pass. Do not proceed if any engine fails.
+All 20 engines must pass. Do not proceed if any engine fails.
 
 ### 4. Commit the release
 
@@ -81,7 +81,7 @@ git push origin develop --tags
 
 ### 7. Verify CI
 
-Wait for the GitHub Actions CI to pass on all 11 engines before proceeding.
+Wait for the GitHub Actions CI to pass on all 20 engines before proceeding.
 
 ### 8. Publish to ForgeBox
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,6 +40,7 @@ SYM_ARROW="${C_DIM}→${C_RESET}"
 # ── Config ───────────────────────────────────────────────────────────────────
 
 ALL_SERVERS=(
+    server-lucee-8-0.json
     server-lucee-7-1.json
     server-lucee-7-0.json
     server-lucee-6-2.json
@@ -47,6 +48,14 @@ ALL_SERVERS=(
     server-lucee-6-0.json
     server-lucee-5-4.json
     server-lucee-5-3.json
+    server-lucee-light-8-0.json
+    server-lucee-light-7-1.json
+    server-lucee-light-7-0.json
+    server-lucee-light-6-2.json
+    server-lucee-light-6-1.json
+    server-lucee-light-6-0.json
+    server-lucee-light-5-4.json
+    server-lucee-light-5-3.json
     server-adobe-2025.json
     server-adobe-2023.json
     server-adobe-2021.json
@@ -100,6 +109,19 @@ get_engine() {
     grep '"cfengine"' "$1" | head -1 | sed 's/.*"cfengine"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
 }
 
+box_server() {
+    local action=$1
+    local config=$2
+    shift 2
+
+    if [[ "$(get_engine "$config")" == lucee*@8.* ]]; then
+        BOX_CONFIG_MODULESEXCLUDE='["commandbox-cfconfig"]' \
+            box server "$action" serverConfigFile="$config" "$@"
+    else
+        box server "$action" serverConfigFile="$config" "$@"
+    fi
+}
+
 # Pretty name: "Lucee 6.1" from "lucee@6.1"
 pretty_engine() {
     local engine
@@ -108,10 +130,11 @@ pretty_engine() {
     vendor=$(echo "$engine" | cut -d@ -f1)
     version=$(echo "$engine" | cut -d@ -f2)
     case "$vendor" in
-        lucee)   echo "Lucee $version" ;;
-        adobe)   echo "Adobe CF $version" ;;
-        boxlang) echo "BoxLang $version" ;;
-        *)       echo "$engine" ;;
+        lucee)       echo "Lucee $version" ;;
+        lucee-light) echo "Lucee Light $version" ;;
+        adobe)       echo "Adobe CF $version" ;;
+        boxlang)     echo "BoxLang $version" ;;
+        *)           echo "$engine" ;;
     esac
 }
 
@@ -150,7 +173,7 @@ cleanup() {
     if [ -n "$CURRENT_SERVER" ]; then
         echo ""
         log "${C_YELLOW}Stopping server (cleanup)...${C_RESET}"
-        box server stop serverConfigFile="$CURRENT_SERVER" 2>/dev/null || true
+        box_server stop "$CURRENT_SERVER" 2>/dev/null || true
         CURRENT_SERVER=""
     fi
 }
@@ -184,12 +207,12 @@ run_single() {
     # Start server
     log "${SYM_DOT} Starting server..."
     CURRENT_SERVER="$config"
-    box server start serverConfigFile="$config" --!verbose --!openBrowser > /dev/null 2>&1
+    box_server start "$config" --!verbose --!openBrowser > /dev/null 2>&1
 
     # Wait for it
     if ! wait_for_server "$port"; then
         log "${SYM_FAIL} Server failed to start within ${MAX_WAIT}s"
-        box server stop serverConfigFile="$config" 2>/dev/null || true
+        box_server stop "$config" 2>/dev/null || true
         CURRENT_SERVER=""
         local elapsed=$(( $(date +%s) - start_time ))
         RESULT_NAMES+=("$engine_pretty")
@@ -275,7 +298,7 @@ print('\n'.join(lines))
 
     # Stop server
     log "${SYM_DOT} Stopping server..."
-    box server stop serverConfigFile="$config" > /dev/null 2>&1 || true
+    box_server stop "$config" > /dev/null 2>&1 || true
     CURRENT_SERVER=""
 
     local elapsed=$(( $(date +%s) - start_time ))

--- a/server-lucee-8-0.json
+++ b/server-lucee-8-0.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-8-0",
+    "app":{
+        "cfengine":"lucee@8.0.0-ALPHA"
+    },
+    "web":{
+        "http":{
+            "port":"9202"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-5-3.json
+++ b/server-lucee-light-5-3.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-5-3",
+    "app":{
+        "cfengine":"lucee-light@5.3"
+    },
+    "web":{
+        "http":{
+            "port":"9203"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-5-4.json
+++ b/server-lucee-light-5-4.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-5-4",
+    "app":{
+        "cfengine":"lucee-light@5.4"
+    },
+    "web":{
+        "http":{
+            "port":"9204"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-6-0.json
+++ b/server-lucee-light-6-0.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-6-0",
+    "app":{
+        "cfengine":"lucee-light@6.0"
+    },
+    "web":{
+        "http":{
+            "port":"9205"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-6-1.json
+++ b/server-lucee-light-6-1.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-6-1",
+    "app":{
+        "cfengine":"lucee-light@6.1"
+    },
+    "web":{
+        "http":{
+            "port":"9206"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-6-2.json
+++ b/server-lucee-light-6-2.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-6-2",
+    "app":{
+        "cfengine":"lucee-light@6.2"
+    },
+    "web":{
+        "http":{
+            "port":"9207"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-7-0.json
+++ b/server-lucee-light-7-0.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-7-0",
+    "app":{
+        "cfengine":"lucee-light@7.0"
+    },
+    "web":{
+        "http":{
+            "port":"9208"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-7-1.json
+++ b/server-lucee-light-7-1.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-7-1",
+    "app":{
+        "cfengine":"lucee-light@7.1.0-BETA"
+    },
+    "web":{
+        "http":{
+            "port":"9209"
+        }
+    },
+    "openbrowser":false
+}

--- a/server-lucee-light-8-0.json
+++ b/server-lucee-light-8-0.json
@@ -1,0 +1,14 @@
+{
+    "trayEnable":false,
+    "profile":"development",
+    "name":"lucee-light-8-0",
+    "app":{
+        "cfengine":"lucee-light@8.0.0-ALPHA"
+    },
+    "web":{
+        "http":{
+            "port":"9210"
+        }
+    },
+    "openbrowser":false
+}

--- a/src/com/raygun/filter/RaygunContentFilter.cfc
+++ b/src/com/raygun/filter/RaygunContentFilter.cfc
@@ -11,7 +11,7 @@ component accessors="true" {
     property name="filter" type="array";
 
     public RaygunContentFilter function init( array filter = [] ) {
-        setFilter( filter );
+        variables.filter = arguments.filter;
         return this;
     }
 


### PR DESCRIPTION
## Summary

- add moving Lucee 8 Alpha and Lucee Light 8 Alpha server configurations
- add Lucee Light configurations matching every supported full Lucee line from 5.3 through 8.0
- expand the local runner, GitHub Actions matrix, and documentation from 11 to 20 engines
- exclude `commandbox-cfconfig` while starting Lucee 8 because CFConfig does not yet provide a Lucee 8 config provider
- avoid the new Adobe CF 2025 `setFilter()` built-in collision when initializing `RaygunContentFilter`

## Verification

- `./run-tests.sh` — all 20 engines passed, 174/174 specs each
- `bash -n run-tests.sh`
- validated all 20 server JSON files, unique names/ports, and parity between local and CI matrices
- `git diff --check`

`box run-script format:check` remains red on 22 pre-existing source/test files. This branch does not reformat those files.