### PR TITLE
chore: release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 History and Plan
 ================
 
-3.0.0-rc.1 (April 13, 2026)
+3.0.0 (July 21, 2026)
 
 New Features:
 
@@ -26,13 +26,14 @@ Bug Fixes:
 - Fixed thread name typo in async sending
 - Fixed typed property defaults (`default=""` on non-string typed properties)
 - Added `isNull()` guards on `getSettings()`/`getContentFilter()` to prevent NPE on strict engines
+- Fixed `RaygunContentFilter` initialization on Adobe ColdFusion 2025 Update 11, where the engine's built-in `setFilter()` function collided with the generated property setter
 
 Code Quality:
 
 - Centralized all magic strings and constants in `RaygunConfig` (API endpoint, log file name, content types, HTTP methods, size limits, timeout/retry defaults)
 - Replaced `isClosure()` with `isCustomFunction()` for cross-engine compatibility
-- 160 test specs (up from 70), covering all components
-- Added Lucee 6.2, 7.0, and 7.1 to test matrix (11 engines total)
+- 174 test specs (up from 70), covering all components
+- Expanded the test matrix to 20 engines, including Lucee 8 Alpha and matching Lucee Light configurations for every supported Lucee line
 
 2.1.0 (Jan 21 2025)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,7 +49,7 @@ Replace the current version in all three locations:
 Change the `(Unreleased)` marker to the version and date:
 
 ```
-3.0.0 (April 15, 2026)
+3.0.0 (July 21, 2026)
 ```
 
 ### 3. Run the full test matrix
@@ -62,28 +62,42 @@ All 20 engines must pass. Do not proceed if any engine fails.
 
 ### 4. Commit the release
 
+Review and stage every intended release-preparation change, including formatting corrections:
+
 ```bash
-git add src/com/raygun/environment/RaygunConfig.cfc box.json CHANGELOG.md tests/specs/com/raygun/environment/RaygunConfigTest.cfc
+git status --short
+git diff
+git add -u
+git diff --cached --check
+git diff --cached --stat
 git commit -m "chore: release x.y.z"
 ```
 
-### 5. Tag the release
+### 5. Merge the release preparation to `develop`
+
+Push the release branch, open a pull request targeting `develop`, wait for all required checks, and merge it.
+
+### 6. Promote `develop` to `master`
+
+Open a release pull request from `develop` to `master`. Wait for all required checks and merge it. The resulting `master` commit is the source of the public release.
+
+### 7. Tag the release
+
+Fetch the merged `master` branch, verify its version strings, and tag that exact commit:
 
 ```bash
+git fetch origin
+git switch master
+git pull --ff-only origin master
 git tag -a x.y.z -m "Release x.y.z"
+git push origin x.y.z
 ```
 
-### 6. Push to remote
+### 8. Verify CI
 
-```bash
-git push origin develop --tags
-```
+Confirm that the `master` release PR passed all 20 engine checks and that the tag points to its merged commit before proceeding.
 
-### 7. Verify CI
-
-Wait for the GitHub Actions CI to pass on all 20 engines before proceeding.
-
-### 8. Publish to ForgeBox
+### 9. Publish to ForgeBox
 
 ```bash
 # Log in if not already authenticated
@@ -95,7 +109,7 @@ box publish
 
 Verify the package at https://www.forgebox.io/view/raygun4cfml
 
-### 9. Create a GitHub Release (optional)
+### 10. Create a GitHub Release
 
 Go to https://github.com/MindscapeHQ/raygun4cfml/releases and create a release from the tag. Copy the relevant section from `CHANGELOG.md` as the release notes.
 
@@ -103,10 +117,19 @@ Go to https://github.com/MindscapeHQ/raygun4cfml/releases and create a release f
 
 After a final release:
 
-1. Bump version to the next snapshot (e.g., `3.1.0-snapshot`) in `RaygunConfig.cfc`, `box.json`, and the test
-2. Add a new `(Unreleased)` section to `CHANGELOG.md`
-3. Commit: `git commit -m "chore: bump version to x.y.z-snapshot"`
-4. Push: `git push origin develop`
+1. Create a post-release branch from the latest `origin/develop`
+2. Bump version to the next snapshot (e.g., `3.1.0-snapshot`) in `RaygunConfig.cfc`, `box.json`, and the test
+3. Add a new `(Unreleased)` section to `CHANGELOG.md`
+4. Commit: `git commit -m "chore: bump version to x.y.z-snapshot"`
+5. Push the branch and merge a pull request targeting `develop`
+
+```bash
+git fetch origin
+git switch -c chore/next-snapshot origin/develop
+# Update the version locations and CHANGELOG.md, then validate the changes.
+git commit -am "chore: bump version to x.y.z-snapshot"
+git push -u origin chore/next-snapshot
+```
 
 ## Promoting RC to Final
 

--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
     "name":"raygun4cfml",
-    "version":"3.0.0-rc.1",
-    "location":"MindscapeHQ/raygun4cfml#3.0.0-rc.1",
+    "version":"3.0.0",
+    "location":"MindscapeHQ/raygun4cfml#3.0.0",
     "author":"Kai Koenig <kai@ventego-creative.co.nz>",
     "homepage":"https://github.com/MindscapeHQ/raygun4cfml/",
     "documentation":"https://github.com/MindscapeHQ/raygun4cfml/blob/master/README.md",

--- a/src/com/raygun/RaygunClient.cfc
+++ b/src/com/raygun/RaygunClient.cfc
@@ -6,11 +6,11 @@
 component accessors="true" {
 
     // Core configuration properties required for Raygun integration
-    property name="apiKey"        type="string"              default="";
+    property name="apiKey" type="string" default="";
     property name="contentFilter" type="RaygunContentFilter";
-    property name="appVersion"    type="string"              default="";
-    property name="settings"      type="RaygunSettings";
-    property name="breadcrumbs"       type="array";
+    property name="appVersion" type="string" default="";
+    property name="settings"         type="RaygunSettings";
+    property name="breadcrumbs"      type="array";
     property name="onBeforeSend"     type="any";
     property name="ignoreExceptions" type="array";
 
@@ -85,9 +85,7 @@ component accessors="true" {
             crumbArgs[ "customData" ] = arguments.customData;
         }
 
-        getBreadcrumbs().append(
-            new message.RaygunBreadcrumbMessage( argumentCollection = crumbArgs )
-        );
+        getBreadcrumbs().append( new message.RaygunBreadcrumbMessage( argumentCollection = crumbArgs ) );
 
         return this;
     }
@@ -324,17 +322,25 @@ component accessors="true" {
         required string jsonData,
         boolean sendAsync = false
     ) {
-        var postResult   = "";
-        var apiEndpoint  = resolveApiEndpoint();
-        var httpTimeout  = resolveHttpTimeout();
-        var maxRetries   = resolveMaxRetries();
-        var retryDelay   = resolveRetryDelay();
+        var postResult  = "";
+        var apiEndpoint = resolveApiEndpoint();
+        var httpTimeout = resolveHttpTimeout();
+        var maxRetries  = resolveMaxRetries();
+        var retryDelay  = resolveRetryDelay();
 
         if ( arguments.sendAsync ) {
             // Use threading for async transmission to prevent blocking the main request
-            thread action="run" name="sendAsyncToRaygunThread_#createUUID()#" apiKey=getApiKey() payload=arguments.jsonData endpoint=apiEndpoint httpTimeoutSecs=httpTimeout retries=maxRetries retryDelaySecs=retryDelay {
-                var attempts = 0;
-                var success  = false;
+            thread
+                action         ="run"
+                name           ="sendAsyncToRaygunThread_#createUUID()#"
+                apiKey         =getApiKey()
+                payload        =arguments.jsonData
+                endpoint       =apiEndpoint
+                httpTimeoutSecs=httpTimeout
+                retries        =maxRetries
+                retryDelaySecs =retryDelay {
+                var attempts   = 0;
+                var success    = false;
 
                 while ( !success && attempts <= attributes.retries ) {
                     try {

--- a/src/com/raygun/environment/RaygunConfig.cfc
+++ b/src/com/raygun/environment/RaygunConfig.cfc
@@ -11,22 +11,22 @@ component {
 
         // Client identifiers used for error tracking and debugging
         RAYGUN_CLIENT_NAME    = "raygun4cfml";
-        RAYGUN_CLIENT_VERSION = "3.0.0-rc.1";
+        RAYGUN_CLIENT_VERSION = "3.0.0";
         RAYGUN_CLIENT_URL     = "https://github.com/MindscapeHQ/raygun4cfml";
 
         // New default status code
         DEFAULT_STATUS_CODE = 500;
 
-        API_ENDPOINT         = "https://api.raygun.com/entries";
-        LOG_FILE_NAME        = "Raygun4CFML";
-        CONTENT_TYPE_HTML    = "text/html";
-        CONTENT_TYPE_FORM    = "application/x-www-form-urlencoded";
-        HTTP_METHOD_GET      = "GET";
+        API_ENDPOINT          = "https://api.raygun.com/entries";
+        LOG_FILE_NAME         = "Raygun4CFML";
+        CONTENT_TYPE_HTML     = "text/html";
+        CONTENT_TYPE_FORM     = "application/x-www-form-urlencoded";
+        HTTP_METHOD_GET       = "GET";
         FORM_FIELD_MAX_LENGTH = 256;
-        MAX_PAYLOAD_SIZE     = 131072;
-        DEFAULT_HTTP_TIMEOUT = 10;
-        DEFAULT_MAX_RETRIES  = 2;
-        DEFAULT_RETRY_DELAY  = 1;
+        MAX_PAYLOAD_SIZE      = 131072;
+        DEFAULT_HTTP_TIMEOUT  = 10;
+        DEFAULT_MAX_RETRIES   = 2;
+        DEFAULT_RETRY_DELAY   = 1;
     }
 
     /**

--- a/src/com/raygun/filter/RaygunContentFilter.cfc
+++ b/src/com/raygun/filter/RaygunContentFilter.cfc
@@ -30,7 +30,11 @@ component accessors="true" {
 
             if ( isWildcard ) {
                 // Wildcard patterns require recursive key walking
-                filterStructByPattern( arguments.messageData, matcher.filter, matcher.replacement );
+                filterStructByPattern(
+                    arguments.messageData,
+                    matcher.filter,
+                    matcher.replacement
+                );
             } else {
                 // Exact match uses the efficient built-in findKey
                 var findKeysByFilter = arguments.messageData.findKey( matcher.filter, "all" );
@@ -56,7 +60,11 @@ component accessors="true" {
                 var rawDataJSON = deserializeJSON( arguments.messageData.details.request.rawData );
 
                 if ( isWildcard ) {
-                    filterStructByPattern( rawDataJSON, matcher.filter, matcher.replacement );
+                    filterStructByPattern(
+                        rawDataJSON,
+                        matcher.filter,
+                        matcher.replacement
+                    );
                 } else {
                     var findRawDataKeysByFilter = rawDataJSON.findKey( matcher.filter, "all" );
 
@@ -94,13 +102,21 @@ component accessors="true" {
                 } else if ( reFindNoCase( regex, key ) > 0 && isSimpleValue( arguments.data[ key ] ) ) {
                     arguments.data[ key ] = arguments.replacement;
                 } else if ( isStruct( arguments.data[ key ] ) || isArray( arguments.data[ key ] ) ) {
-                    filterStructByPattern( arguments.data[ key ], arguments.pattern, arguments.replacement );
+                    filterStructByPattern(
+                        arguments.data[ key ],
+                        arguments.pattern,
+                        arguments.replacement
+                    );
                 }
             }
         } else if ( isArray( arguments.data ) ) {
             for ( var item in arguments.data ) {
                 if ( isStruct( item ) || isArray( item ) ) {
-                    filterStructByPattern( item, arguments.pattern, arguments.replacement );
+                    filterStructByPattern(
+                        item,
+                        arguments.pattern,
+                        arguments.replacement
+                    );
                 }
             }
         }
@@ -111,7 +127,7 @@ component accessors="true" {
      * Escapes regex-special characters and replaces * with .*
      */
     private string function globToRegex( required string pattern ) {
-        var result      = "";
+        var result       = "";
         var specialChars = ".+?^${}()|[]\";
         var chars        = arguments.pattern.toCharArray();
 

--- a/src/com/raygun/message/RaygunBreadcrumbMessage.cfc
+++ b/src/com/raygun/message/RaygunBreadcrumbMessage.cfc
@@ -51,13 +51,13 @@ component accessors="true" {
 
     public struct function build() {
         var result = {
-            "timestamp" : getTimestamp(),
-            "level"     : getLevel(),
-            "type"      : getType(),
-            "category"  : getCategory(),
-            "message"   : getMessage(),
-            "className" : getClassName(),
-            "methodName": getMethodName()
+            "timestamp"  : getTimestamp(),
+            "level"      : getLevel(),
+            "type"       : getType(),
+            "category"   : getCategory(),
+            "message"    : getMessage(),
+            "className"  : getClassName(),
+            "methodName" : getMethodName()
         };
 
         try {

--- a/src/com/raygun/message/RaygunEnvironmentMessage.cfc
+++ b/src/com/raygun/message/RaygunEnvironmentMessage.cfc
@@ -77,7 +77,7 @@ component {
         }
 
         try {
-            var rawOffset = createObject( "java", "java.util.TimeZone" ).getDefault().getRawOffset();
+            var rawOffset                = createObject( "java", "java.util.TimeZone" ).getDefault().getRawOffset();
             returnContent[ "utcOffset" ] = javacast( "double", rawOffset / 3600000 );
         } catch ( any e ) {
             returnContent[ "utcOffset" ] = javacast( "null", "" );

--- a/src/com/raygun/message/RaygunRequestMessage.cfc
+++ b/src/com/raygun/message/RaygunRequestMessage.cfc
@@ -52,14 +52,19 @@ component accessors="true" {
 
         // Build core request data using safe local copies, defaulting to null for missing values
         var cgiVal = function( required string key ) {
-            return ( localCGI.keyExists( arguments.key ) && len( localCGI[ arguments.key ] ) ) ? localCGI[ arguments.key ] : javacast( "null", "" );
+            return ( localCGI.keyExists( arguments.key ) && len( localCGI[ arguments.key ] ) ) ? localCGI[ arguments.key ] : javacast(
+                "null",
+                ""
+            );
         };
 
         var truncatedForm = truncateFormFields( localForm );
 
         returnContent = {
-            "hostName"    : cgiVal( "HTTP_HOST" ),
-            "url"         : ( !isNull( cgiVal( "SCRIPT_NAME" ) ) ? cgiVal( "SCRIPT_NAME" ) : "" ) & ( !isNull( cgiVal( "PATH_INFO" ) ) ? cgiVal( "PATH_INFO" ) : "" ),
+            "hostName" : cgiVal( "HTTP_HOST" ),
+            "url"      : ( !isNull( cgiVal( "SCRIPT_NAME" ) ) ? cgiVal( "SCRIPT_NAME" ) : "" ) & (
+                !isNull( cgiVal( "PATH_INFO" ) ) ? cgiVal( "PATH_INFO" ) : ""
+            ),
             "httpMethod"  : cgiVal( "REQUEST_METHOD" ),
             "iPAddress"   : cgiVal( "REMOTE_ADDR" ),
             "queryString" : cgiVal( "QUERY_STRING" ),
@@ -76,8 +81,8 @@ component accessors="true" {
 
         // Only include raw request data for non-standard content types to avoid duplicating form data
         // Also enforces a max length to prevent oversized payloads
-        var contentType    = localCGI.keyExists( "CONTENT_TYPE" ) ? localCGI[ "CONTENT_TYPE" ] : "";
-        var requestMethod  = localCGI.keyExists( "REQUEST_METHOD" ) ? localCGI[ "REQUEST_METHOD" ] : "";
+        var contentType   = localCGI.keyExists( "CONTENT_TYPE" ) ? localCGI[ "CONTENT_TYPE" ] : "";
+        var requestMethod = localCGI.keyExists( "REQUEST_METHOD" ) ? localCGI[ "REQUEST_METHOD" ] : "";
         if (
             len( contentType ) && len( requestMethod ) && contentType != com.raygun.environment.RaygunConfig::getContentTypeHtml() && contentType != com.raygun.environment.RaygunConfig::getContentTypeForm() && requestMethod != com.raygun.environment.RaygunConfig::getHttpMethodGet()
         ) {

--- a/tests/specs/com/raygun/RaygunClientBreadcrumbTest.cfc
+++ b/tests/specs/com/raygun/RaygunClientBreadcrumbTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunClient breadcrumbs", function() {
-
             beforeEach( function() {
                 variables.rgClient = new com.raygun.RaygunClient( apiKey = "test-key" );
             } );
@@ -54,9 +53,7 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should clear all breadcrumbs", function() {
-                variables.rgClient
-                    .recordBreadcrumb( message = "first" )
-                    .recordBreadcrumb( message = "second" );
+                variables.rgClient.recordBreadcrumb( message = "first" ).recordBreadcrumb( message = "second" );
 
                 expect( variables.rgClient.getBreadcrumbs() ).toHaveLength( 2 );
 
@@ -64,15 +61,16 @@ component extends="testbox.system.BaseSpec" {
                 expect( result ).toBeInstanceOf( "com.raygun.RaygunClient" );
                 expect( variables.rgClient.getBreadcrumbs() ).toHaveLength( 0 );
             } );
-
         } );
 
         describe( "RaygunMessageDetails breadcrumbs integration", function() {
-
             it( "should include breadcrumbs in payload when provided", function() {
                 var crumbs = [
                     new com.raygun.message.RaygunBreadcrumbMessage( message = "Step 1" ),
-                    new com.raygun.message.RaygunBreadcrumbMessage( message = "Step 2", level = "warning" )
+                    new com.raygun.message.RaygunBreadcrumbMessage(
+                        message = "Step 2",
+                        level   = "warning"
+                    )
                 ];
 
                 var details = new com.raygun.message.RaygunMessageDetails();
@@ -103,7 +101,6 @@ component extends="testbox.system.BaseSpec" {
 
                 expect( structKeyExists( result, "breadcrumbs" ) ).toBeFalse();
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/RaygunClientIgnoreExceptionsTest.cfc
+++ b/tests/specs/com/raygun/RaygunClientIgnoreExceptionsTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunClient ignoreExceptions", function() {
-
             it( "should initialize with empty ignore list by default", function() {
                 var rgClient = new com.raygun.RaygunClient( apiKey = "test-key" );
                 expect( rgClient.getIgnoreExceptions() ).toBeArray();
@@ -23,12 +22,14 @@ component extends="testbox.system.BaseSpec" {
                     ignoreExceptions = [ "MissingInclude" ]
                 );
 
-                var result = rgClient.send( issueData = {
-                    message    : "File not found",
-                    type       : "MissingInclude",
-                    stacktrace : "",
-                    tagcontext : []
-                } );
+                var result = rgClient.send(
+                    issueData = {
+                        message    : "File not found",
+                        type       : "MissingInclude",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( result ).toBe( "" );
             } );
@@ -39,12 +40,14 @@ component extends="testbox.system.BaseSpec" {
                     ignoreExceptions = [ "missinginclude" ]
                 );
 
-                var result = rgClient.send( issueData = {
-                    message    : "File not found",
-                    type       : "MissingInclude",
-                    stacktrace : "",
-                    tagcontext : []
-                } );
+                var result = rgClient.send(
+                    issueData = {
+                        message    : "File not found",
+                        type       : "MissingInclude",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( result ).toBe( "" );
             } );
@@ -75,12 +78,14 @@ component extends="testbox.system.BaseSpec" {
                 rgClient.setIgnoreExceptions( [ "CustomError" ] );
                 expect( rgClient.getIgnoreExceptions() ).toHaveLength( 1 );
 
-                var result = rgClient.send( issueData = {
-                    message    : "Custom",
-                    type       : "CustomError",
-                    stacktrace : "",
-                    tagcontext : []
-                } );
+                var result = rgClient.send(
+                    issueData = {
+                        message    : "Custom",
+                        type       : "CustomError",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( result ).toBe( "" );
             } );
@@ -91,21 +96,35 @@ component extends="testbox.system.BaseSpec" {
                     ignoreExceptions = [ "MissingInclude", "AbortException", "LockTimeout" ]
                 );
 
-                var result1 = rgClient.send( issueData = {
-                    message : "a", type : "MissingInclude", stacktrace : "", tagcontext : []
-                } );
-                var result2 = rgClient.send( issueData = {
-                    message : "b", type : "AbortException", stacktrace : "", tagcontext : []
-                } );
-                var result3 = rgClient.send( issueData = {
-                    message : "c", type : "LockTimeout", stacktrace : "", tagcontext : []
-                } );
+                var result1 = rgClient.send(
+                    issueData = {
+                        message    : "a",
+                        type       : "MissingInclude",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
+                var result2 = rgClient.send(
+                    issueData = {
+                        message    : "b",
+                        type       : "AbortException",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
+                var result3 = rgClient.send(
+                    issueData = {
+                        message    : "c",
+                        type       : "LockTimeout",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( result1 ).toBe( "" );
                 expect( result2 ).toBe( "" );
                 expect( result3 ).toBe( "" );
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/RaygunClientOnBeforeSendTest.cfc
+++ b/tests/specs/com/raygun/RaygunClientOnBeforeSendTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunClient onBeforeSend hook", function() {
-
             it( "should accept onBeforeSend closure in constructor", function() {
                 var cb = function( payload ) {
                     return payload;
@@ -23,7 +22,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should allow setting onBeforeSend via setter", function() {
                 var rgClient = new com.raygun.RaygunClient( apiKey = "test-key" );
-                var cb = function( payload ) {
+                var cb       = function( payload ) {
                     return payload;
                 };
                 rgClient.setOnBeforeSend( cb );
@@ -32,7 +31,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should pass the payload struct to the callback", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -42,12 +41,14 @@ component extends="testbox.system.BaseSpec" {
                     onBeforeSend = cb
                 );
 
-                rgClient.send( issueData = {
-                    message    : "Test error",
-                    type       : "Application",
-                    stacktrace : "",
-                    tagcontext : []
-                } );
+                rgClient.send(
+                    issueData = {
+                        message    : "Test error",
+                        type       : "Application",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( capturedPayload ).toBeStruct();
                 expect( capturedPayload ).toHaveKey( "occurredOn" );
@@ -66,12 +67,14 @@ component extends="testbox.system.BaseSpec" {
                     onBeforeSend = cb
                 );
 
-                var result = rgClient.send( issueData = {
-                    message    : "Test error",
-                    type       : "Application",
-                    stacktrace : "",
-                    tagcontext : []
-                } );
+                var result = rgClient.send(
+                    issueData = {
+                        message    : "Test error",
+                        type       : "Application",
+                        stacktrace : "",
+                        tagcontext : []
+                    }
+                );
 
                 expect( result ).toBe( "" );
             } );
@@ -122,7 +125,6 @@ component extends="testbox.system.BaseSpec" {
                     );
                 } ).notToThrow();
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/RaygunClientPayloadTest.cfc
+++ b/tests/specs/com/raygun/RaygunClientPayloadTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunClient payload size enforcement", function() {
-
             it( "should have a max payload size constant of 131072", function() {
                 expect( com.raygun.environment.RaygunConfig::getMaxPayloadSize() ).toBe( 131072 );
             } );
@@ -10,9 +9,7 @@ component extends="testbox.system.BaseSpec" {
             it( "should build a payload that does not exceed max payload size", function() {
                 var largeData = repeatString( "x", 200000 );
 
-                var customData = new com.raygun.user.RaygunUserCustomData(
-                    { "bigField" : largeData }
-                );
+                var customData = new com.raygun.user.RaygunUserCustomData( { "bigField" : largeData } );
 
                 var client = new com.raygun.RaygunClient( apiKey = "test-key" );
 
@@ -34,7 +31,10 @@ component extends="testbox.system.BaseSpec" {
                 messageContent.details[ "userCustomData" ] = { "bigField" : largeData };
 
                 var jsonData = serializeJSON( messageContent );
-                expect( len( jsonData ) ).toBeGT( 131072, "Test setup: payload should exceed max size" );
+                expect( len( jsonData ) ).toBeGT(
+                    131072,
+                    "Test setup: payload should exceed max size"
+                );
             } );
 
             it( "should initialize RaygunClient without error", function() {
@@ -47,12 +47,14 @@ component extends="testbox.system.BaseSpec" {
                 var rgClient = new com.raygun.RaygunClient( apiKey = "" );
 
                 expect( function() {
-                    rgClient.send( issueData = {
-                        message    : "Test",
-                        type       : "Application",
-                        stacktrace : "",
-                        tagcontext : []
-                    } );
+                    rgClient.send(
+                        issueData = {
+                            message    : "Test",
+                            type       : "Application",
+                            stacktrace : "",
+                            tagcontext : []
+                        }
+                    );
                 } ).toThrow();
             } );
 
@@ -67,7 +69,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should accept contentFilter in constructor", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "password", replacement : "[filtered]" }
+                    {
+                        filter      : "password",
+                        replacement : "[filtered]"
+                    }
                 ] );
 
                 var rgClient = new com.raygun.RaygunClient(
@@ -88,7 +93,6 @@ component extends="testbox.system.BaseSpec" {
 
                 expect( rgClient.getSettings() ).toBeInstanceOf( "com.raygun.environment.RaygunSettings" );
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/SamplePatternsTest.cfc
+++ b/tests/specs/com/raygun/SamplePatternsTest.cfc
@@ -7,10 +7,9 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "Sample pattern: try-catch (samples/try-catch)", function() {
-
             it( "should capture a division-by-zero error with correct payload structure", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -41,14 +40,12 @@ component extends="testbox.system.BaseSpec" {
                 expect( capturedPayload.details.error ).toHaveKey( "message" );
                 expect( capturedPayload.details.error ).toHaveKey( "className" );
             } );
-
         } );
 
         describe( "Sample pattern: app-cfc-no-filter (samples/app-cfc-no-filter)", function() {
-
             it( "should include custom user data in the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -72,7 +69,7 @@ component extends="testbox.system.BaseSpec" {
                 );
 
                 raygun.send(
-                    issueData      = {
+                    issueData = {
                         message    : "variable [TEST5678] doesn't exist",
                         type       : "Expression",
                         stacktrace : "",
@@ -90,7 +87,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should include tags in the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -119,7 +116,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should include user identification in the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -154,21 +151,25 @@ component extends="testbox.system.BaseSpec" {
                 expect( capturedPayload.details.user.fullName ).toBe( "Tester" );
                 expect( capturedPayload.details.user.uuid ).toBe( "47e432fff11" );
             } );
-
         } );
 
         describe( "Sample pattern: app-cfc-content-filter (samples/app-cfc-content-filter)", function() {
-
             it( "should filter sensitive fields from the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
 
                 var filterRaw = [
-                    { filter : "password", replacement : "__password__" },
-                    { filter : "creditcard", replacement : "__ccnumber__" }
+                    {
+                        filter      : "password",
+                        replacement : "__password__"
+                    },
+                    {
+                        filter      : "creditcard",
+                        replacement : "__ccnumber__"
+                    }
                 ];
                 var contentFilter = new com.raygun.filter.RaygunContentFilter( filterRaw );
 
@@ -203,14 +204,20 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should filter with wildcard patterns", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
 
                 var contentFilter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "pass*", replacement : "[FILTERED]" },
-                    { filter : "*token", replacement : "[FILTERED]" }
+                    {
+                        filter      : "pass*",
+                        replacement : "[FILTERED]"
+                    },
+                    {
+                        filter      : "*token",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var customUserData = new com.raygun.user.RaygunUserCustomData( {
@@ -243,14 +250,12 @@ component extends="testbox.system.BaseSpec" {
                 expect( capturedPayload.details.userCustomData.refreshtoken ).toBe( "[FILTERED]" );
                 expect( capturedPayload.details.userCustomData.username ).toBe( "visible" );
             } );
-
         } );
 
         describe( "Sample pattern: app-cfc-settings (samples/app-cfc-settings)", function() {
-
             it( "should use custom settings for status code", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -295,7 +300,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should auto-set 404 status for MissingInclude exceptions", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -316,14 +321,12 @@ component extends="testbox.system.BaseSpec" {
 
                 expect( capturedPayload.details.response.statusCode ).toBe( 404 );
             } );
-
         } );
 
         describe( "Sample pattern: breadcrumbs (README example)", function() {
-
             it( "should include breadcrumbs in the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -343,7 +346,10 @@ component extends="testbox.system.BaseSpec" {
                     lineNumber = 42,
                     customData = { "sql" : "SELECT * FROM users WHERE id = ?" }
                 );
-                raygun.recordBreadcrumb( message = "Page rendered", level = "info" );
+                raygun.recordBreadcrumb(
+                    message = "Page rendered",
+                    level   = "info"
+                );
 
                 raygun.send(
                     issueData = {
@@ -375,14 +381,12 @@ component extends="testbox.system.BaseSpec" {
                 var crumb3 = capturedPayload.details.breadcrumbs[ 3 ];
                 expect( crumb3.message ).toBe( "Page rendered" );
             } );
-
         } );
 
         describe( "Sample pattern: ignore exceptions (README example)", function() {
-
             it( "should skip ignored exception types", function() {
                 var callbackInvoked = false;
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     callbackInvoked = true;
                     return false;
                 };
@@ -408,7 +412,7 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should send non-ignored exception types normally", function() {
                 var callbackInvoked = false;
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     callbackInvoked = true;
                     return false;
                 };
@@ -430,14 +434,12 @@ component extends="testbox.system.BaseSpec" {
 
                 expect( callbackInvoked ).toBeTrue();
             } );
-
         } );
 
         describe( "Sample pattern: full onError (README full example)", function() {
-
             it( "should produce a complete payload with all features combined", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -454,8 +456,14 @@ component extends="testbox.system.BaseSpec" {
                     .setFullName( "Jane Smith" );
 
                 var contentFilter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "pass*", replacement : "[FILTERED]" },
-                    { filter : "creditCard", replacement : "[FILTERED]" }
+                    {
+                        filter      : "pass*",
+                        replacement : "[FILTERED]"
+                    },
+                    {
+                        filter      : "creditCard",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var settings = new com.raygun.environment.RaygunSettings(
@@ -473,7 +481,10 @@ component extends="testbox.system.BaseSpec" {
                     onBeforeSend     = cb
                 );
 
-                raygun.recordBreadcrumb( message = "Error handler triggered", level = "error" );
+                raygun.recordBreadcrumb(
+                    message = "Error handler triggered",
+                    level   = "error"
+                );
 
                 raygun.send(
                     issueData = {
@@ -519,14 +530,12 @@ component extends="testbox.system.BaseSpec" {
                 expect( details ).toHaveKey( "environment" );
                 expect( details ).toHaveKey( "request" );
             } );
-
         } );
 
         describe( "Sample pattern: grouping key", function() {
-
             it( "should include a custom grouping key in the payload", function() {
                 var capturedPayload = {};
-                var cb = function( payload ) {
+                var cb              = function( payload ) {
                     capturedPayload = payload;
                     return false;
                 };
@@ -549,7 +558,6 @@ component extends="testbox.system.BaseSpec" {
                 expect( capturedPayload.details ).toHaveKey( "groupingKey" );
                 expect( capturedPayload.details.groupingKey ).toBe( "my-custom-grouping-key" );
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/environment/RaygunConfigTest.cfc
+++ b/tests/specs/com/raygun/environment/RaygunConfigTest.cfc
@@ -11,13 +11,11 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should provide client version", function() {
-                expect( com.raygun.environment.RaygunConfig::getRaygunClientVersion() ).toBe( "3.0.0-rc.1" );
+                expect( com.raygun.environment.RaygunConfig::getRaygunClientVersion() ).toBe( "3.0.0" );
             } );
 
             it( "should provide client URL", function() {
-                expect( com.raygun.environment.RaygunConfig::getRaygunClientUrl() ).toBe(
-                    "https://github.com/MindscapeHQ/raygun4cfml"
-                );
+                expect( com.raygun.environment.RaygunConfig::getRaygunClientUrl() ).toBe( "https://github.com/MindscapeHQ/raygun4cfml" );
             } );
 
             it( "should provide default status code", function() {
@@ -25,9 +23,7 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should provide API endpoint", function() {
-                expect( com.raygun.environment.RaygunConfig::getApiEndpoint() ).toBe(
-                    "https://api.raygun.com/entries"
-                );
+                expect( com.raygun.environment.RaygunConfig::getApiEndpoint() ).toBe( "https://api.raygun.com/entries" );
             } );
 
             it( "should provide log file name", function() {
@@ -39,9 +35,7 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should provide form content type", function() {
-                expect( com.raygun.environment.RaygunConfig::getContentTypeForm() ).toBe(
-                    "application/x-www-form-urlencoded"
-                );
+                expect( com.raygun.environment.RaygunConfig::getContentTypeForm() ).toBe( "application/x-www-form-urlencoded" );
             } );
 
             it( "should provide HTTP GET method", function() {

--- a/tests/specs/com/raygun/environment/RaygunSettingsTest.cfc
+++ b/tests/specs/com/raygun/environment/RaygunSettingsTest.cfc
@@ -36,23 +36,17 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should initialize with default API endpoint", function() {
-                expect( variables.settings.getApiEndpoint() ).toBe(
-                    com.raygun.environment.RaygunConfig::getApiEndpoint()
-                );
+                expect( variables.settings.getApiEndpoint() ).toBe( com.raygun.environment.RaygunConfig::getApiEndpoint() );
             } );
 
             it( "should initialize with custom API endpoint", function() {
-                var settings = new com.raygun.environment.RaygunSettings(
-                    apiEndpoint = "https://custom.example.com/entries"
-                );
+                var settings = new com.raygun.environment.RaygunSettings( apiEndpoint = "https://custom.example.com/entries" );
                 expect( settings.getApiEndpoint() ).toBe( "https://custom.example.com/entries" );
             } );
 
             it( "should include API endpoint in settings struct", function() {
-                var settings = new com.raygun.environment.RaygunSettings(
-                    apiEndpoint = "https://custom.example.com/entries"
-                );
-                var result = settings.getSettings();
+                var settings = new com.raygun.environment.RaygunSettings( apiEndpoint = "https://custom.example.com/entries" );
+                var result   = settings.getSettings();
                 expect( result.apiEndpoint ).toBe( "https://custom.example.com/entries" );
             } );
 

--- a/tests/specs/com/raygun/filter/RaygunContentFilterWildcardTest.cfc
+++ b/tests/specs/com/raygun/filter/RaygunContentFilterWildcardTest.cfc
@@ -2,10 +2,12 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunContentFilter wildcard filtering", function() {
-
             it( "should filter keys matching a prefix wildcard pattern", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "pass*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "pass*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var messageData = {
@@ -25,7 +27,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should filter keys matching a suffix wildcard pattern", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "*token", replacement : "[FILTERED]" }
+                    {
+                        filter      : "*token",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var messageData = {
@@ -43,15 +48,18 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should filter keys matching a contains wildcard pattern", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "*secret*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "*secret*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var messageData = {
-                    mySecretKey   : "hidden",
-                    secretValue   : "hidden",
-                    topSecret123  : "hidden",
-                    publicData    : "visible",
-                    details       : { request : {} }
+                    mySecretKey  : "hidden",
+                    secretValue  : "hidden",
+                    topSecret123 : "hidden",
+                    publicData   : "visible",
+                    details      : { request : {} }
                 };
 
                 var result = filter.apply( messageData );
@@ -63,11 +71,18 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should filter nested struct keys with wildcards", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "api*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "api*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var messageData = {
-                    nested  : { apiKey : "hidden", apiSecret : "hidden", name : "visible" },
+                    nested : {
+                        apiKey    : "hidden",
+                        apiSecret : "hidden",
+                        name      : "visible"
+                    },
                     details : { request : {} }
                 };
 
@@ -79,7 +94,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should match wildcards case-insensitively", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "credit*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "credit*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var messageData = {
@@ -97,7 +115,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should not filter complex values with wildcards", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "pass*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "pass*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var complexValue = { nested : "data" };
@@ -112,7 +133,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should filter wildcard patterns in rawData JSON", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "api*", replacement : "[FILTERED]" }
+                    {
+                        filter      : "api*",
+                        replacement : "[FILTERED]"
+                    }
                 ] );
 
                 var jsonData = {
@@ -121,9 +145,7 @@ component extends="testbox.system.BaseSpec" {
                     username  : "test"
                 };
 
-                var messageData = {
-                    details : { request : { rawData : serializeJSON( jsonData ) } }
-                };
+                var messageData = { details : { request : { rawData : serializeJSON( jsonData ) } } };
 
                 var result        = filter.apply( messageData );
                 var processedJson = deserializeJSON( result.details.request.rawData );
@@ -134,8 +156,14 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should still support exact match filters alongside wildcards", function() {
                 var filter = new com.raygun.filter.RaygunContentFilter( [
-                    { filter : "password", replacement : "[exact]" },
-                    { filter : "api*", replacement : "[wildcard]" }
+                    {
+                        filter      : "password",
+                        replacement : "[exact]"
+                    },
+                    {
+                        filter      : "api*",
+                        replacement : "[wildcard]"
+                    }
                 ] );
 
                 var messageData = {
@@ -148,7 +176,6 @@ component extends="testbox.system.BaseSpec" {
                 expect( result.password ).toBe( "[exact]" );
                 expect( result.apiKey ).toBe( "[wildcard]" );
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunBreadcrumbMessageTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunBreadcrumbMessageTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunBreadcrumbMessage", function() {
-
             it( "should initialize with required message", function() {
                 var crumb = new com.raygun.message.RaygunBreadcrumbMessage( message = "User clicked button" );
                 expect( crumb.getMessage() ).toBe( "User clicked button" );
@@ -45,34 +44,24 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should validate level and default invalid levels to info", function() {
-                var crumb = new com.raygun.message.RaygunBreadcrumbMessage(
-                    message = "test",
-                    level   = "critical"
-                );
+                var crumb = new com.raygun.message.RaygunBreadcrumbMessage( message = "test", level = "critical" );
                 expect( crumb.getLevel() ).toBe( "info" );
             } );
 
             it( "should accept all valid levels", function() {
                 var levels = [ "debug", "info", "warning", "error" ];
                 for ( var lvl in levels ) {
-                    var crumb = new com.raygun.message.RaygunBreadcrumbMessage(
-                        message = "test",
-                        level   = lvl
-                    );
+                    var crumb = new com.raygun.message.RaygunBreadcrumbMessage( message = "test", level = lvl );
                     expect( crumb.getLevel() ).toBe( lvl );
                 }
             } );
 
             it( "should handle case-insensitive level validation", function() {
-                var crumb = new com.raygun.message.RaygunBreadcrumbMessage(
-                    message = "test",
-                    level   = "WARNING"
-                );
+                var crumb = new com.raygun.message.RaygunBreadcrumbMessage( message = "test", level = "WARNING" );
                 expect( crumb.getLevel() ).toBe( "warning" );
             } );
 
             describe( "build()", function() {
-
                 it( "should return a struct with required fields", function() {
                     var crumb  = new com.raygun.message.RaygunBreadcrumbMessage( message = "test" );
                     var result = crumb.build();
@@ -88,10 +77,7 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 it( "should include lineNumber when set", function() {
-                    var crumb  = new com.raygun.message.RaygunBreadcrumbMessage(
-                        message    = "test",
-                        lineNumber = 99
-                    );
+                    var crumb  = new com.raygun.message.RaygunBreadcrumbMessage( message = "test", lineNumber = 99 );
                     var result = crumb.build();
                     expect( result ).toHaveKey( "lineNumber" );
                     expect( result.lineNumber ).toBe( 99 );
@@ -104,7 +90,7 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 it( "should include customData when set", function() {
-                    var crumb  = new com.raygun.message.RaygunBreadcrumbMessage(
+                    var crumb = new com.raygun.message.RaygunBreadcrumbMessage(
                         message    = "test",
                         customData = { "key" : "value" }
                     );
@@ -118,9 +104,7 @@ component extends="testbox.system.BaseSpec" {
                     var result = crumb.build();
                     expect( structKeyExists( result, "customData" ) ).toBeFalse();
                 } );
-
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunEnvironmentMessageTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunEnvironmentMessageTest.cfc
@@ -6,7 +6,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunEnvironmentMessage", function() {
-
             it( "should initialize without error", function() {
                 expect( variables.envMessage ).toBeInstanceOf( "com.raygun.message.RaygunEnvironmentMessage" );
             } );
@@ -69,7 +68,6 @@ component extends="testbox.system.BaseSpec" {
                     variables.envMessage.build();
                 } ).notToThrow();
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunExceptionMessageBugTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunExceptionMessageBugTest.cfc
@@ -6,9 +6,7 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunExceptionMessage bugs", function() {
-
             describe( "BUG: stackTrace should be populated from tagcontext when stacktrace string is empty", function() {
-
                 it( "should populate stackTrace from tagcontext when stacktrace is empty", function() {
                     // BUG: When a CFML exception has an empty stacktrace string but a populated
                     // tagcontext array, the Raygun API field error.stackTrace ends up as an empty
@@ -48,7 +46,6 @@ component extends="testbox.system.BaseSpec" {
                         expect( result.stackTrace[ 1 ] ).toHaveKey( "fileName" );
                     }
                 } );
-
             } );
 
             describe( "BUG: case-sensitive type check for database errors", function() {
@@ -68,7 +65,8 @@ component extends="testbox.system.BaseSpec" {
 
                     var result = variables.exceptionMessage.build( dbException );
 
-                    expect( result.data ).toHaveKey( "database",
+                    expect( result.data ).toHaveKey(
+                        "database",
                         "Database errors should be detected regardless of type casing"
                     );
                     expect( result.data.database.sql ).toBe( "SELECT * FROM users" );
@@ -86,13 +84,12 @@ component extends="testbox.system.BaseSpec" {
 
                     var result = variables.exceptionMessage.build( dbException );
 
-                    expect( result.data ).toHaveKey( "database",
+                    expect( result.data ).toHaveKey(
+                        "database",
                         "DATABASE (uppercase) should be detected as a database error"
                     );
                 } );
-
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunMessageDetailsTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunMessageDetailsTest.cfc
@@ -2,14 +2,13 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunMessageDetails", function() {
-
             it( "should initialize without error", function() {
                 var details = new com.raygun.message.RaygunMessageDetails();
                 expect( details ).toBeInstanceOf( "com.raygun.message.RaygunMessageDetails" );
             } );
 
             it( "should build a complete payload struct from minimal issue data", function() {
-                var details = new com.raygun.message.RaygunMessageDetails();
+                var details   = new com.raygun.message.RaygunMessageDetails();
                 var issueData = {
                     message    : "Test error",
                     type       : "Application",
@@ -73,7 +72,10 @@ component extends="testbox.system.BaseSpec" {
 
             it( "should propagate settings to sub-components", function() {
                 var details = new com.raygun.message.RaygunMessageDetails(
-                    settings = { "rawDataMaxLength" : 200, "statusCode" : 503 }
+                    settings = {
+                        "rawDataMaxLength" : 200,
+                        "statusCode"       : 503
+                    }
                 );
 
                 // Response should use the custom status code
@@ -99,7 +101,6 @@ component extends="testbox.system.BaseSpec" {
                     } );
                 } ).notToThrow();
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunMessageTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunMessageTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunMessage", function() {
-
             it( "should initialize without error", function() {
                 var msg = new com.raygun.message.RaygunMessage();
                 expect( msg ).toBeInstanceOf( "com.raygun.message.RaygunMessage" );
@@ -35,9 +34,7 @@ component extends="testbox.system.BaseSpec" {
             } );
 
             it( "should propagate settings to RaygunMessageDetails", function() {
-                var msg    = new com.raygun.message.RaygunMessage(
-                    settings = { "statusCode" : 418 }
-                );
+                var msg    = new com.raygun.message.RaygunMessage( settings = { "statusCode" : 418 } );
                 var result = msg.build( {
                     message    : "Test error",
                     type       : "Application",
@@ -63,7 +60,6 @@ component extends="testbox.system.BaseSpec" {
                 expect( result.details ).toHaveKey( "environment" );
                 expect( result.details ).toHaveKey( "response" );
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunRequestMessageFormTruncationTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunRequestMessageFormTruncationTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunRequestMessage form field truncation", function() {
-
             it( "should have a form field max length constant of 256", function() {
                 expect( com.raygun.environment.RaygunConfig::getFormFieldMaxLength() ).toBe( 256 );
             } );
@@ -14,7 +13,6 @@ component extends="testbox.system.BaseSpec" {
                 expect( result ).toHaveKey( "form" );
                 expect( result.form ).toBeStruct();
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunRequestMessageTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunRequestMessageTest.cfc
@@ -2,16 +2,12 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunRequestMessage", function() {
-
             describe( "BUG: settings propagation", function() {
-
                 it( "should use custom rawDataMaxLength from settings passed at construction", function() {
                     // BUG: RaygunMessageDetails creates RaygunRequestMessage() without settings,
                     // so even if settings are passed later, rawDataMaxLength is never applied.
                     var customLength = 50;
-                    var msg          = new com.raygun.message.RaygunRequestMessage(
-                        settings = { "rawDataMaxLength" : customLength }
-                    );
+                    var msg          = new com.raygun.message.RaygunRequestMessage( settings = { "rawDataMaxLength" : customLength } );
 
                     // The settings should be stored and accessible
                     expect( msg.getSettings() ).toHaveKey( "rawDataMaxLength" );
@@ -22,9 +18,7 @@ component extends="testbox.system.BaseSpec" {
                     // BUG: RaygunMessageDetails.build() calls raygunRequestMessage.build( getSettings() )
                     // but RaygunRequestMessage.build() accepts NO arguments — settings are ignored.
                     // The fix should make build() use this.getSettings() internally.
-                    var msg = new com.raygun.message.RaygunRequestMessage(
-                        settings = { "rawDataMaxLength" : 100 }
-                    );
+                    var msg = new com.raygun.message.RaygunRequestMessage( settings = { "rawDataMaxLength" : 100 } );
 
                     // Settings should be stored and available for build() to use
                     expect( msg.getSettings() ).toBeStruct();
@@ -35,29 +29,23 @@ component extends="testbox.system.BaseSpec" {
                     var result = msg.build();
                     expect( result ).toBeStruct();
                 } );
-
             } );
 
             describe( "BUG: settings propagation through RaygunMessageDetails", function() {
-
                 it( "should pass settings to RaygunRequestMessage when created by RaygunMessageDetails", function() {
                     // BUG: RaygunMessageDetails.init() creates `new RaygunRequestMessage()` without settings
                     // on line 35, so settings never reach the request message builder.
                     var customSettings = { "rawDataMaxLength" : 100 };
-                    var details        = new com.raygun.message.RaygunMessageDetails(
-                        settings = customSettings
-                    );
+                    var details        = new com.raygun.message.RaygunMessageDetails( settings = customSettings );
 
                     // The internal RaygunRequestMessage should have received the settings
                     var requestMsg = details.getRaygunRequestMessage();
                     expect( requestMsg.getSettings() ).toHaveKey( "rawDataMaxLength" );
                     expect( requestMsg.getSettings().rawDataMaxLength ).toBe( 100 );
                 } );
-
             } );
 
             describe( "build() contract", function() {
-
                 it( "should return a struct with expected request keys", function() {
                     var msg    = new com.raygun.message.RaygunRequestMessage();
                     var result = msg.build();
@@ -81,9 +69,7 @@ component extends="testbox.system.BaseSpec" {
                         msg.build();
                     } ).notToThrow();
                 } );
-
             } );
-
         } );
     }
 

--- a/tests/specs/com/raygun/message/RaygunResponseMessageBugTest.cfc
+++ b/tests/specs/com/raygun/message/RaygunResponseMessageBugTest.cfc
@@ -2,7 +2,6 @@ component extends="testbox.system.BaseSpec" {
 
     function run() {
         describe( "RaygunResponseMessage bugs", function() {
-
             describe( "BUG: case-sensitive MissingInclude check", function() {
                 // NOTE: On Lucee, == is case-insensitive so these pass by accident.
                 // On ACF, == is case-sensitive so these would fail without a fix.
@@ -12,7 +11,8 @@ component extends="testbox.system.BaseSpec" {
                     var msg    = new com.raygun.message.RaygunResponseMessage( { "statusCode" : 500 } );
                     var result = msg.build( { "type" : "missinginclude" } );
 
-                    expect( result.statusCode ).toBe( 404,
+                    expect( result.statusCode ).toBe(
+                        404,
                         "missinginclude (lowercase) should map to 404"
                     );
                 } );
@@ -21,13 +21,12 @@ component extends="testbox.system.BaseSpec" {
                     var msg    = new com.raygun.message.RaygunResponseMessage( { "statusCode" : 500 } );
                     var result = msg.build( { "type" : "MISSINGINCLUDE" } );
 
-                    expect( result.statusCode ).toBe( 404,
+                    expect( result.statusCode ).toBe(
+                        404,
                         "MISSINGINCLUDE (uppercase) should map to 404"
                     );
                 } );
-
             } );
-
         } );
     }
 


### PR DESCRIPTION
## Summary

- promote Raygun4CFML from `3.0.0-rc.1` to final `3.0.0`
- finalize the changelog for the Adobe CF 2025 Update 11 compatibility fix and expanded 20-engine matrix
- apply the repository formatter to clear the pre-existing formatting release gate
- update the release guide for protected `develop`/`master` branch promotion

## Verification

- `./run-tests.sh` — all 20 engines passed, 174/174 specs each
  - Lucee and Lucee Light 5.3 through 8.0 Alpha
  - Adobe ColdFusion 2021, 2023, and 2025
  - BoxLang 1
- `box run-script format:check`
- `bash -n run-tests.sh`
- synchronized `3.0.0` across `box.json`, `RaygunConfig.cfc`, and its version assertion
- `git diff --check`

## Release flow after merge

Once this preparation lands on `develop`, promote `develop` to `master` in a release PR. Tag the exact merged `master` commit as `3.0.0`, then publish to ForgeBox and create the GitHub Release.